### PR TITLE
feat: add Website structured metadata for site name

### DIFF
--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -3,3 +3,11 @@
 <!-- Make the translated search clear button label available for use in JS -->
 <!-- See buildClearSearchButton() in script.js -->
 <script type="text/javascript">window.searchClearButtonLabelLocalized = "{{t 'search_clear'}}";</script>
+<script type="application/ld+json">
+    {
+        "@context" : "https://schema.org",
+        "@type" : "WebSite",
+        "name" : "MIT OpenCourseWare Help Center",
+        "url" : "https://mitocw.zendesk.com/hc/en-us"
+    }
+</script>

--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -7,7 +7,7 @@
     {
         "@context" : "https://schema.org",
         "@type" : "WebSite",
-        "name" : "MIT OpenCourseWare Help Center",
+        "name" : "{{help_center.name}}",
         "url" : "https://mitocw.zendesk.com/hc/en-us"
     }
 </script>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7970

### Description
This PR adds the website structured metadata to help Google with better detection of the site name in search results, as recommended [here](https://developers.google.com/search/docs/appearance/site-names#how-site-names-in-google-search-are-created).

While we only need this on the home page, adding it to the document_head template (as done here) adds it to the `<head>` for all pages. I couldn't find a way online or in the templating [docs](https://developer.zendesk.com/api-reference/help_center/help-center-templates/introduction/) to restrict that to the homepage only. I do not expect any negative impact from this though.

### How can this be tested?
I have set up a trial zendesk account and deployed this theme update [there](https://arbisoft-75361.zendesk.com). Visit that zendesk instance and verify that the Website structured object is present in the head and has the appropriate fields.